### PR TITLE
feat/add GitHub inline error annotation

### DIFF
--- a/xra/src/hbs_helpers.rs
+++ b/xra/src/hbs_helpers.rs
@@ -6,6 +6,7 @@ use handlebars::JsonRender;
 use handlebars::Output;
 use handlebars::RenderContext;
 use handlebars::RenderErrorReason;
+use std::env;
 
 pub fn result_to_emoji(
     helper: &Helper,
@@ -47,7 +48,8 @@ pub fn get_file_name(
         .map(|v| v.value().as_str())
         .unwrap_or_default();
     if let Some(file) = parse_file_location(location.unwrap_or("")) {
-        out.write(&file)?;
+        let relative_file = strip_pwd(&file);
+        out.write(&relative_file)?;
     }
     Ok(())
 }
@@ -79,4 +81,14 @@ fn parse_file_location(location: &str) -> Option<String> {
     let (locations, _) = location.split_once(";").unwrap_or((location, ""));
     let (file, _) = locations.split_once(':')?;
     Some(file.to_string())
+}
+
+fn strip_pwd(file_path: &str) -> String {
+    let current_dir = env::current_dir().expect("Failed to get current directory");
+    let path = std::path::Path::new(file_path);
+
+    match path.strip_prefix(&current_dir) {
+        Ok(relative_path) => relative_path.to_string_lossy().to_string(),
+        Err(_) => file_path.to_string(),
+    }
 }

--- a/xra/src/hbs_helpers.rs
+++ b/xra/src/hbs_helpers.rs
@@ -34,3 +34,55 @@ pub fn result_to_emoji(
 
     Ok(())
 }
+
+pub fn get_file_name(
+    helper: &Helper,
+    _: &Handlebars,
+    _: &Context,
+    _: &mut RenderContext,
+    out: &mut dyn Output,
+) -> HelperResult {
+    let location = helper
+        .param(0)
+        .map(|v| v.value().as_str())
+        .unwrap_or_default();
+    if let Some((file, _, _)) = parse_location(location.unwrap_or("")) {
+        out.write(file)?;
+    }
+    Ok(())
+}
+
+pub fn get_line(
+    helper: &Helper,
+    _: &Handlebars,
+    _: &Context,
+    _: &mut RenderContext,
+    out: &mut dyn Output,
+) -> HelperResult {
+    let location = helper
+        .param(0)
+        .map(|v| v.value().as_str())
+        .unwrap_or_default();
+    if let Some((_, line, _)) = parse_location(location.unwrap_or("")) {
+        out.write(&line.to_string())?;
+    }
+    Ok(())
+}
+
+fn parse_location(location: &str) -> Option<(&str, u32, Option<u32>)> {
+    let parts: Vec<&str> = location.split(':').collect();
+    match parts.len() {
+        2 => {
+            let file = parts[0];
+            let line = parts[1].parse::<u32>().ok()?;
+            Some((file, line, None))
+        }
+        3 => {
+            let file = parts[0];
+            let line = parts[1].parse::<u32>().ok()?;
+            let col = parts[2].parse::<u32>().ok()?;
+            Some((file, line, Some(col)))
+        }
+        _ => None,
+    }
+}

--- a/xra/src/hbs_helpers.rs
+++ b/xra/src/hbs_helpers.rs
@@ -46,8 +46,8 @@ pub fn get_file_name(
         .param(0)
         .map(|v| v.value().as_str())
         .unwrap_or_default();
-    if let Some((file, _, _)) = parse_location(location.unwrap_or("")) {
-        out.write(file)?;
+    if let Some(file) = parse_file_location(location.unwrap_or("")) {
+        out.write(&file)?;
     }
     Ok(())
 }
@@ -63,26 +63,20 @@ pub fn get_line(
         .param(0)
         .map(|v| v.value().as_str())
         .unwrap_or_default();
-    if let Some((_, line, _)) = parse_location(location.unwrap_or("")) {
+    if let Some(line) = parse_file_line(location.unwrap_or("")) {
         out.write(&line.to_string())?;
     }
     Ok(())
 }
 
-fn parse_location(location: &str) -> Option<(&str, u32, Option<u32>)> {
-    let parts: Vec<&str> = location.split(':').collect();
-    match parts.len() {
-        2 => {
-            let file = parts[0];
-            let line = parts[1].parse::<u32>().ok()?;
-            Some((file, line, None))
-        }
-        3 => {
-            let file = parts[0];
-            let line = parts[1].parse::<u32>().ok()?;
-            let col = parts[2].parse::<u32>().ok()?;
-            Some((file, line, Some(col)))
-        }
-        _ => None,
-    }
+fn parse_file_line(location: &str) -> Option<u32> {
+    let (locations, _) = location.split_once(";").unwrap_or((location, ""));
+    let (_, line) = locations.split_once(':')?;
+    line.parse().ok()
+}
+
+fn parse_file_location(location: &str) -> Option<String> {
+    let (locations, _) = location.split_once(";").unwrap_or((location, ""));
+    let (file, _) = locations.split_once(':')?;
+    Some(file.to_string())
 }

--- a/xra/src/main.rs
+++ b/xra/src/main.rs
@@ -16,6 +16,8 @@ fn main() -> anyhow::Result<()> {
     let args = Cli::parse();
     let mut reg = Handlebars::new();
     reg.register_helper("toEmoji", Box::new(hbs_helpers::result_to_emoji));
+    reg.register_helper("getFileName", Box::new(hbs_helpers::get_file_name));
+    reg.register_helper("getLine", Box::new(hbs_helpers::get_line));
 
     match args {
         Cli::Generate(Generate::Database { xcresult_path }) => {

--- a/xra/src/main.rs
+++ b/xra/src/main.rs
@@ -110,6 +110,7 @@ fn main() -> anyhow::Result<()> {
             let content = fs::read_to_string(&path)
                 .with_context(|| format!("Failed to read template file: {}", path.display()))?;
             let content = reg.render_template(&content, &params)?;
+
             fs::write(output, content)?;
         }
         Cli::Generate(Generate::Report {

--- a/xra/src/templates.rs
+++ b/xra/src/templates.rs
@@ -7,6 +7,7 @@ pub enum ResultTemplate {
 pub enum FailureResultTemplate {
     Markdown,
     Slack,
+    GitHubAnnoation,
 }
 
 impl ResultTemplate {
@@ -93,6 +94,12 @@ impl FailureResultTemplate {
 	]
 }
                 "#
+            .to_owned(),
+            Self::GitHubAnnoation => r#"
+{{#each test_results}}
+::error file={{getFileName name}},line={{getLine error_location}}::{{failure_reason}}
+{{/each}}
+            "#
             .to_owned(),
         }
     }

--- a/xra/src/templates.rs
+++ b/xra/src/templates.rs
@@ -7,7 +7,7 @@ pub enum ResultTemplate {
 pub enum FailureResultTemplate {
     Markdown,
     Slack,
-    GitHubAnnoation,
+    GithubAnnotation,
 }
 
 impl ResultTemplate {
@@ -95,11 +95,11 @@ impl FailureResultTemplate {
 }
                 "#
             .to_owned(),
-            Self::GitHubAnnoation => r#"
+            Self::GithubAnnotation => r#"
 {{#each test_results}}
-::error file={{getFileName name}},line={{getLine error_location}}::{{failure_reason}}
+::error file={{getFileName error_locations}},line={{getLine error_locations}}::{{failure_reason}}
 {{/each}}
-            "#
+"#
             .to_owned(),
         }
     }

--- a/xra_core/src/dba.rs
+++ b/xra_core/src/dba.rs
@@ -46,6 +46,27 @@ impl Dba {
             })?
             .flatten()
             .collect::<Vec<_>>();
+
+        // for test_result in rows.clone() {
+        //     // Process error locations and failure reasons
+        //     let location_parts: Vec<&str> = test_result
+        //         .error_locations
+        //         .as_deref()
+        //         .unwrap_or("")
+        //         .split(';')
+        //         .collect();
+        //     let reason_parts: Vec<&str> = test_result.failure_reasons.split(';').collect();
+
+        //     // Loop through the locations and reasons
+        //     for (location, reason) in location_parts.iter().zip(reason_parts.iter()) {
+        //         if let Some((file, line, col)) = parse_location(location) {
+        //             let _ = log_github_action_annotation(file, line, col, "error", reason);
+        //         } else {
+        //             println!("Failed to parse location: {}", location);
+        //         }
+        //     }
+        // }
+
         Ok(TestFailedResults { test_results: rows })
     }
 
@@ -78,12 +99,12 @@ pub struct TestFailedResults {
     test_results: Vec<FailedTestRunResult>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct FailedTestRunResult {
     name: String,
     failure_count: i64,
     failure_reasons: String,
-    error_locations: String,
+    error_locations: Option<String>,
     average_duration: f64,
 }
 

--- a/xra_core/src/dba.rs
+++ b/xra_core/src/dba.rs
@@ -46,27 +46,6 @@ impl Dba {
             })?
             .flatten()
             .collect::<Vec<_>>();
-
-        // for test_result in rows.clone() {
-        //     // Process error locations and failure reasons
-        //     let location_parts: Vec<&str> = test_result
-        //         .error_locations
-        //         .as_deref()
-        //         .unwrap_or("")
-        //         .split(';')
-        //         .collect();
-        //     let reason_parts: Vec<&str> = test_result.failure_reasons.split(';').collect();
-
-        //     // Loop through the locations and reasons
-        //     for (location, reason) in location_parts.iter().zip(reason_parts.iter()) {
-        //         if let Some((file, line, col)) = parse_location(location) {
-        //             let _ = log_github_action_annotation(file, line, col, "error", reason);
-        //         } else {
-        //             println!("Failed to parse location: {}", location);
-        //         }
-        //     }
-        // }
-
         Ok(TestFailedResults { test_results: rows })
     }
 

--- a/xra_core/src/lib.rs
+++ b/xra_core/src/lib.rs
@@ -3,13 +3,13 @@ mod macros;
 pub mod dba;
 pub mod error;
 
+use dba::Dba;
+use std::fs;
 use std::fs::OpenOptions;
+use std::io;
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
-use std::{fs, io};
-
-use dba::Dba;
 
 pub fn generate_xcresult_db(xcresult_path: &PathBuf) -> Result<(), error::XcraError> {
     if !fs::exists(xcresult_path)? {

--- a/xra_core/src/lib.rs
+++ b/xra_core/src/lib.rs
@@ -5,7 +5,6 @@ pub mod error;
 
 use dba::Dba;
 use std::fs;
-use std::fs::OpenOptions;
 use std::io;
 use std::io::Write;
 use std::path::PathBuf;
@@ -89,37 +88,5 @@ pub fn get_tests_report(xcresult_path: &PathBuf) -> Result<(), error::XcraError>
     let dba = Dba::new(&xcresult_path.display().to_string())?;
     let results = dba.get_test_results()?;
     println!("{:#?}", results);
-    Ok(())
-}
-
-pub fn log_github_action_annotation(
-    file: &str,
-    line: u32,
-    col: Option<u32>,
-    level: &str,
-    message: &str,
-) -> io::Result<()> {
-    let mut log_file = OpenOptions::new()
-        .create(true) // Create the file if it doesn't exist
-        .append(true) // Append to the file
-        .open("error_logs.txt")?; // Open the log file (path is "error_logs.txt")
-
-    match col {
-        Some(col) => {
-            writeln!(
-                log_file,
-                "::{} file={},line={},col={}::{}",
-                level, file, line, col, message
-            )?;
-        }
-        None => {
-            writeln!(
-                log_file,
-                "::{} file={},line={}::{}",
-                level, file, line, message
-            )?;
-        }
-    }
-
     Ok(())
 }


### PR DESCRIPTION
This PR adds GitHub annotation support for test results, providing detailed error information such as relative file paths, line numbers, and failure reasons. These annotations enhance debugging by directly linking test failures to specific files and lines in the GitHub UI, improving error visibility and traceability.

### Key Changes:

**1. GitHub Annotation Format:**
  The output follows the GitHub Actions annotation format:
```
 ::error file=<relative_path>,line=<line_number>::<failure_reason>
```
**2. Dynamic Relative File Paths:**
    Added logic to compute relative file paths based on the current working directory, ensuring annotations are concise and readable.

**3. Integration with Handlebars:**
    Registered custom Handlebars helpers (getFileName, getLine) to process file paths and line numbers dynamically during template rendering.

**4. Template Update:**
 Modified the error reporting template to produce annotations in the required format.