### PR TITLE
add failure_reasons in GitHub annotation template

### DIFF
--- a/xra/src/templates.rs
+++ b/xra/src/templates.rs
@@ -97,7 +97,7 @@ impl FailureResultTemplate {
             .to_owned(),
             Self::GithubAnnotation => r#"
 {{#each test_results}}
-::error file={{getFileName error_locations}},line={{getLine error_locations}}::{{failure_reason}}
+::error file={{getFileName error_locations}},line={{getLine error_locations}}::{{failure_reasons}}
 {{/each}}
 "#
             .to_owned(),


### PR DESCRIPTION
This PR includes a small fix for adding failure_reasons in the template for github-annotation. 